### PR TITLE
solve: 2352(3)

### DIFF
--- a/2352.py
+++ b/2352.py
@@ -1,21 +1,15 @@
-from collections import List
+from collections import List, Counter
 
 class Solution:
-    def rotate(self, grid: List[List[int]]) -> List[List[int]]:
-        reval = []
+    def equalPairs(self, grid: List[List[int]]) -> int:
+        cnt = Counter(tuple(row) for row in grid)
+
         n = len(grid)
+        answer = 0
         for j in range(n):
             row = []
             for i in range(n):
                 row.append(grid[i][j])
-            reval.append(row)
-        return reval
-
-    def equalPairs(self, grid: List[List[int]]) -> int:
-        grid2 = self.rotate(grid)
-        answer = 0
-        for r1 in grid:
-            for r2 in grid2:
-                if r1 == r2: answer += 1
+            answer += cnt[tuple(row)]
 
         return answer


### PR DESCRIPTION
https://leetcode.com/problems/equal-row-and-column-pairs/?envType=study-plan-v2&envId=leetcode-75

grid의 row를 tuple로 변환해 각 row에 대한 Counter를 만든 뒤,
grid를 회전 시키며 회전된 row와 일치하는 기존 grid의 행의 개수를 answer에 누적하여 더함